### PR TITLE
add observable of the queue length

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ This defaults to
 function (err) { if(err) console.error(err) }
 ```
 
+### ScrollSink.visible ()
+
+call this function when the scroller becomes visible,
+and any new items will be added.
+
+### ScrollSink.observ => observable
+
+An observable of the queue size of this scroller.
+this is useful to show how many items can be displayed, but are not.
+which is useful for showing activity indicators and similar.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
   var stream = pull(
     pause,
     pull.drain(function (e) {
-      console.log('enqueue', e)
       queue.push(e)
       obv.set(queue.length)
 
@@ -106,4 +105,5 @@ function append(scroller, list, el, isPrepend, isSticky) {
     scroller.scrollTop = scroller.scrollTop + d
   }
 }
+
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/dominictarr/pull-scroll.git"
   },
   "dependencies": {
+    "obv": "0.0.1",
     "pull-pause": "0.0.0",
     "pull-stream": "^3.0.1"
   },


### PR DESCRIPTION
this adds an `observ` property which can be used to track whether there is new content available.

This is useful to show how many items can be displayed, but are not displayed yet.
which is useful for showing activity indicators and similar.
