### PR TITLE
fix overloading of content on scroll

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
   function scroll (ev) {
     if(isEnd(scroller, buffer, isPrepend) || !isFilled(content)) {
       pause.resume()
-      add()
     }
   }
 
@@ -63,7 +62,6 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
   var stream = pull(
     pause,
     pull.drain(function (e) {
-      console.log('enqueue', e)
       queue.push(e)
       obv.set(queue.length)
 


### PR DESCRIPTION
The interface is loading way too much content and lagging up.
I've removed the add() here and it works as I'm expecting it (i.e. loads only when you get near the bottom).

It's a significant improvement. 
**NOTE** I think master on github is out of sync with master on your computer / npm @dominictarr , can sync all the things before you publish?

cheers! 