### PR TITLE
fix isFilled bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,9 +47,6 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
 
   function scroll (ev) {
     if(isEnd(scroller, buffer, isPrepend) || !isFilled(content)) {
-      for (var i = 0; i < 5; i++) {
-        add()
-      }
       pause.resume()
     }
   }
@@ -107,3 +104,4 @@ function append(scroller, list, el, isPrepend, isSticky) {
     scroller.scrollTop = scroller.scrollTop + d
   }
 }
+

--- a/index.js
+++ b/index.js
@@ -47,6 +47,9 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
 
   function scroll (ev) {
     if(isEnd(scroller, buffer, isPrepend) || !isFilled(content)) {
+      for (var i = 0; i < 5; i++) {
+        add()
+      }
       pause.resume()
     }
   }
@@ -104,4 +107,3 @@ function append(scroller, list, el, isPrepend, isSticky) {
     scroller.scrollTop = scroller.scrollTop + d
   }
 }
-

--- a/utils.js
+++ b/utils.js
@@ -17,7 +17,7 @@ function isFilled(content) {
     // && content.getBoundingClientRect().height == 0
     //and has children. if there are no children,
     //it might be size zero because it hasn't started yet.
-    && content.children.length > 10
+    || content.children.length > 10
     //&& !isVisible(scroller)
   )
 }
@@ -54,4 +54,3 @@ function isBottom (scroller, buffer) {
   return scroller.scrollTop >=
     + ((topmax) - (buffer || 0))
 }
-


### PR DESCRIPTION
It's possible to build up a queue of items that haven't yet been added to the dom. This PR keeps adding the items after the stream ends (otherwise they never load).

Not sure if this is the best way of handling or if something else even stranger is going on. But this at least is fixing the "feeds not loading" issue in patchwork-next.

There was also a problem with the boolean logic on `isVisible` which became apparent after I added the drain.

cc @ahdinosaur @dominictarr 