### PR TITLE
correctly drain queue when stream finishes

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
 
   function scroll (ev) {
     if(isEnd(scroller, buffer, isPrepend) || !isFilled(content)) {
+      add()
       pause.resume()
     }
   }


### PR DESCRIPTION
**This PR ensures that the queue is properly drained after a stream finishes. Fixes the issue described on [%0OY+mZo8xLdX8+HQXfv8LSZJNmaW5doSVluu+EH63bA=.sha256](https://viewer.scuttlebot.io/%250OY%2BmZo8xLdX8%2BHQXfv8LSZJNmaW5doSVluu%2BEH63bA%3D.sha256)**

Without this, `add()` is only called on drain. If the stream has finished, but there are still items in the queue, they will never get added to the DOM.

Does this look good to you @dominictarr?