### PR TITLE
handle display:none as well as visibility:hidden

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,12 +66,14 @@ function Scroller(scroller, content, render, isPrepend, isSticky, cb) {
       queue.push(e)
       obv.set(queue.length)
 
-      if(scroller.scrollHeight < window.innerHeight)
-        add()
-
       if (isVisible(content)) {
         if (isEnd(scroller, buffer, isPrepend))
           add()
+      }
+      else {
+        if(scroller.scrollHeight < window.innerHeight && content.children.length < 10) {
+          add()
+        }
       }
 
       if(queue.length > 5)
@@ -114,7 +116,6 @@ function append(scroller, list, el, isPrepend, isSticky) {
     }
   }
 }
-
 
 
 

--- a/utils.js
+++ b/utils.js
@@ -22,9 +22,12 @@ function isFilled(content) {
   )
 }
 
-function isVisible(el) {
+function isVisible (el) {
+  if(!el) return false
+  if(el === document.body) return true
   var style = getComputedStyle(el)
-  return style.visibility !== 'hidden'
+  if(style.visibility === 'hidden' || style.display === 'none') return false
+  return isVisible(el.parentElement)
 }
 
 module.exports = {
@@ -54,3 +57,6 @@ function isBottom (scroller, buffer) {
   return scroller.scrollTop >=
     + ((topmax) - (buffer || 0))
 }
+
+
+


### PR DESCRIPTION
This makes pull-scroll work with the old way of managing hypertabs (display:none) not just visibility: hidden, also it should work by removing the element from the DOM.

This will mean minbay can just use the latest pull-scroll